### PR TITLE
Task/rcsd 24 add ability to delete user

### DIFF
--- a/src/main/java/com/digital/receipt/app/user/client/UserClient.java
+++ b/src/main/java/com/digital/receipt/app/user/client/UserClient.java
@@ -73,4 +73,16 @@ public class UserClient {
     public User updateUser(User user) throws SqlFragmentNotFoundException, IOException {
         return userController.updateUser(user);
     }
+
+    /**
+     * Will delete a user for the given id. This endpoint can only be accessed by a
+     * user with admin access.
+     * 
+     * @param id of the user that is to be deleted.
+     * @throws IOException
+     * @throws SqlFragmentNotFoundException
+     */
+    public void deleteUser(int id) throws SqlFragmentNotFoundException, IOException {
+        userController.deleteUser(id);
+    }
 }

--- a/src/main/java/com/digital/receipt/app/user/dao/UserDao.java
+++ b/src/main/java/com/digital/receipt/app/user/dao/UserDao.java
@@ -115,6 +115,29 @@ public class UserDao extends AbstractSqlDao {
     }
 
     /**
+     * Will set the forgot password flag to the given boolean value.
+     * 
+     * @param flag The flag to set the forgot password too.
+     * @return user associated to that id with the updated information
+     * @throws IOException
+     * @throws SqlFragmentNotFoundException
+     */
+    public User updateUserForgotPassword(boolean flag) throws SqlFragmentNotFoundException, IOException {
+        User userProfile = getUserById(jwtHolder.getRequiredUserId());
+        int userId = userProfile.getId();
+        Optional<Integer> updatedRow = Optional.of(0);
+
+        updatedRow = sqlClient.update(bundler.bundle(getSql("updateUserForgotPassword"),
+                params("flag", flag ? 1 : 0).addValue("id", userId)));
+
+        if (!updatedRow.isPresent()) {
+            throw new UserNotFoundException(
+                    String.format("User not found! Could not update user for id: '%i'", userId));
+        }
+        return userProfile;
+    }
+
+    /**
      * Maps non null user fields from the source to the desitnation.
      * 
      * @param destination Where the null fields should be replaced.

--- a/src/main/java/com/digital/receipt/app/user/dao/UserDao.java
+++ b/src/main/java/com/digital/receipt/app/user/dao/UserDao.java
@@ -61,7 +61,11 @@ public class UserDao extends AbstractSqlDao {
      * @throws SqlFragmentNotFoundException
      */
     public User getUserById(int id) throws SqlFragmentNotFoundException, IOException {
-        return sqlClient.getTemplate(bundler.bundle(getSql("getUserById"), params("userId", id)), USER_MAPPER);
+        try {
+            return sqlClient.getTemplate(bundler.bundle(getSql("getUserById"), params("userId", id)), USER_MAPPER);
+        } catch (Exception e) {
+            throw new UserNotFoundException(String.format("User not found for id: %d", id));
+        }
     }
 
     /**
@@ -135,6 +139,18 @@ public class UserDao extends AbstractSqlDao {
                     String.format("User not found! Could not update user for id: '%i'", userId));
         }
         return userProfile;
+    }
+
+    /**
+     * Will delete a user for the given id. This endpoint can only be accessed by a
+     * user with admin access.
+     * 
+     * @param id of the user that is to be deleted.
+     * @throws IOException
+     * @throws SqlFragmentNotFoundException
+     */
+    public void deleteUser(int id) throws SqlFragmentNotFoundException, IOException {
+        sqlClient.delete(bundler.bundle(getSql("deleteUser"), params("id", id)));
     }
 
     /**

--- a/src/main/java/com/digital/receipt/app/user/rest/UserController.java
+++ b/src/main/java/com/digital/receipt/app/user/rest/UserController.java
@@ -14,6 +14,7 @@ import com.digital.receipt.common.enums.WebRole;
 import com.digital.receipt.common.exceptions.SqlFragmentNotFoundException;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -88,5 +89,19 @@ public class UserController {
     @HasAccess(WebRole.USER)
     public User updateUser(@RequestBody User user) throws SqlFragmentNotFoundException, IOException {
         return userService.updateUser(user);
+    }
+
+    /**
+     * Will delete a user for the given id. This endpoint can only be accessed by a
+     * user with admin access.
+     * 
+     * @param id of the user that is to be deleted.
+     * @throws IOException
+     * @throws SqlFragmentNotFoundException
+     */
+    @DeleteMapping("/{id}")
+    @HasAccess(WebRole.ADMIN)
+    public void deleteUser(@PathVariable int id) throws SqlFragmentNotFoundException, IOException {
+        userService.deleteUser(id);
     }
 }

--- a/src/main/java/com/digital/receipt/app/user/service/UserService.java
+++ b/src/main/java/com/digital/receipt/app/user/service/UserService.java
@@ -80,6 +80,19 @@ public class UserService {
     }
 
     /**
+     * Will delete a user for the given id. This endpoint can only be accessed by a
+     * user with admin access.
+     * 
+     * @param id of the user that is to be deleted.
+     * @throws IOException
+     * @throws SqlFragmentNotFoundException
+     */
+    public void deleteUser(int id) throws SqlFragmentNotFoundException, IOException {
+        getUserById(id);
+        userDao.deleteUser(id);
+    }
+
+    /**
      * Update the user for the given user object.
      * 
      * @param user what information on the user needs to be updated.

--- a/src/main/java/com/digital/receipt/app/user/service/UserService.java
+++ b/src/main/java/com/digital/receipt/app/user/service/UserService.java
@@ -31,7 +31,7 @@ public class UserService {
     private JwtHolder jwtHolder;
 
     /**
-     * Get users based on given request filter
+     * Get users based on given request filter.
      * 
      * @param request of the user
      * @return User profile object {@link User}
@@ -43,7 +43,7 @@ public class UserService {
     }
 
     /**
-     * Service to get a users profile given the user id
+     * Service to get a users profile given the user id.
      * 
      * @param id of the user
      * @return User profile object {@link User}
@@ -55,7 +55,7 @@ public class UserService {
     }
 
     /**
-     * Get the current user from the jwt token
+     * Get the current user from the jwt token.
      * 
      * @return User profile object {@link User}
      * @throws IOException
@@ -75,11 +75,12 @@ public class UserService {
      */
     public User updateUser(User user) throws SqlFragmentNotFoundException, IOException {
         updateUserPassword(user.getPassword());
+        updateUserForgotPassword(user.isForgotPassword());
         return updateUserProfile(user);
     }
 
     /**
-     * Update the user for the given user object
+     * Update the user for the given user object.
      * 
      * @param user what information on the user needs to be updated.
      * @return user associated to that id with the updated information
@@ -91,7 +92,7 @@ public class UserService {
     }
 
     /**
-     * Update the users credentials
+     * Update the users credentials.
      * 
      * @param user what information on the user needs to be updated.
      * @return user associated to that id with the updated information
@@ -108,5 +109,17 @@ public class UserService {
         } catch (NoSuchAlgorithmException e) {
             throw new BaseException("Could not hash password!");
         }
+    }
+
+    /**
+     * Will set the forgot password flag to the given boolean value.
+     * 
+     * @param flag The flag to set the forgot password too.
+     * @return user associated to that id with the updated information
+     * @throws IOException
+     * @throws SqlFragmentNotFoundException
+     */
+    public User updateUserForgotPassword(boolean flag) throws SqlFragmentNotFoundException, IOException {
+        return userDao.updateUserForgotPassword(flag);
     }
 }

--- a/src/main/resources/dao/UserDao.sql
+++ b/src/main/resources/dao/UserDao.sql
@@ -51,3 +51,10 @@
     	password = :password:
 	WHERE
 		user_id = :id:
+
+@NAME(updateUserForgotPassword)
+    UPDATE user_credentials 
+	SET 
+    	forgot_password_flag = :flag:
+	WHERE
+		user_id = :id:

--- a/src/main/resources/dao/UserDao.sql
+++ b/src/main/resources/dao/UserDao.sql
@@ -58,3 +58,8 @@
     	forgot_password_flag = :flag:
 	WHERE
 		user_id = :id:
+
+@NAME(deleteUser)
+	DELETE FROM user_profile
+	WHERE
+    	id = :id:


### PR DESCRIPTION
### What Changed:
- Added delete user endpoint.
- This will only be able to be used by admins.


### Testing:
- Can use the below endpoint to confirm that it is able to delete a user. First you will need to create a dummy user so that you have a user to delete.
- Type: `DELETE`
- Endpoint: `https://digital-receipt-pr-4.herokuapp.com/api/user-app/users/:id:`